### PR TITLE
Fix Raven.captureException example in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ And then use `Raven.captureException` as the error handler like this:
 
 ```javascript
 const store = createStore(reducer, applyMiddleware(
-  reduxCatch(Raven.captureException)
+  reduxCatch(function (error) {
+    Raven.captureException(error);
+  });
 ));
 ```
 


### PR DESCRIPTION
`Raven.captureException` cannot be passed as a function reference; it needs to be bound to `Raven` (either via `bind` or by being wrapped in a function).